### PR TITLE
Go version 1.15 & fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.15
       id: go
 
     - name: Check out code into the Go module directory

--- a/cmd/app/use_test.go
+++ b/cmd/app/use_test.go
@@ -40,7 +40,7 @@ func TestRunAppUseNotServer(t *testing.T) {
 	args := []string{}
 	err := runAppUse(&cmd, args)
 
-	assert.Equal(t, "Get http:///apps: http: no Host in request URL", err.Error())
+	assert.Equal(t, `Get "http:///apps": http: no Host in request URL`, err.Error())
 }
 
 func TestRunAppUseNotFound(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stormkit-io/stormkit-cli
 
-go 1.12
+go 1.15
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0


### PR DESCRIPTION
version:

updated to go version `1.15`
- `go.mod`
- `.github/workflow/test.yml`

fix tests for go `1.15`
- `cmd/app/use_test.go`