### PR TITLE
Fix cmd app ls dump

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/stormkit-io/stormkit-cli/stormkit"
 )
 
+const dumpAppPrintf = "Repo: %s\n  ID: %s\n  Status: %t\n  AutoDeploy: %s\n  DefaultEnv: %s\n  Endpoint: %s\n  DisplayName: %s\n  CreatedAt: %s\n  DeployedAt: %s\n\n"
 const getApps = "/apps"
 
 // App is the model of an app
@@ -70,4 +72,20 @@ func GetApps() (*Apps, error) {
 	err = json.Unmarshal(body, &a)
 
 	return &a, err
+}
+
+// DumpApp in a string with all the parameters of the app
+func DumpApp(a App) string {
+	return fmt.Sprintf(
+		dumpAppPrintf,
+		a.Repo,
+		a.ID,
+		a.Status,
+		a.AutoDeploy,
+		a.DefaultEnv,
+		a.Endpoint,
+		a.DisplayName,
+		time.Unix(int64(a.CreatedAt), 0),
+		time.Unix(int64(a.DeployedAt), 0),
+	)
 }

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -62,3 +62,8 @@ func TestGetApps403(t *testing.T) {
 	assert.Nil(t, apps)
 	assert.Contains(t, err.Error(), http.StatusText(http.StatusForbidden))
 }
+
+func TestDumpApp(t *testing.T) {
+	s := DumpApp(ExpectedApps.Apps[0])
+	assert.Equal(t, "Repo: repo1\n  ID: 1234\n  Status: false\n  AutoDeploy: \n  DefaultEnv: \n  Endpoint: \n  DisplayName: \n  CreatedAt: 1970-01-01 01:00:00 +0100 CET\n  DeployedAt: 1970-01-01 01:00:00 +0100 CET\n\n", s)
+}

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stormkit-io/stormkit-cli/stormkit"
@@ -65,5 +67,9 @@ func TestGetApps403(t *testing.T) {
 
 func TestDumpApp(t *testing.T) {
 	s := DumpApp(ExpectedApps.Apps[0])
-	assert.Equal(t, "Repo: repo1\n  ID: 1234\n  Status: false\n  AutoDeploy: \n  DefaultEnv: \n  Endpoint: \n  DisplayName: \n  CreatedAt: 1970-01-01 01:00:00 +0100 CET\n  DeployedAt: 1970-01-01 01:00:00 +0100 CET\n\n", s)
+	createdAt := time.Unix(int64(ExpectedApps.Apps[0].CreatedAt), 0)
+	deployedAt := time.Unix(int64(ExpectedApps.Apps[0].DeployedAt), 0)
+	expected := fmt.Sprintf("Repo: repo1\n  ID: 1234\n  Status: false\n  AutoDeploy: \n  DefaultEnv: \n  Endpoint: \n  DisplayName: \n  CreatedAt: %s\n  DeployedAt: %s\n\n", createdAt, deployedAt)
+
+	assert.Equal(t, expected, s)
 }

--- a/cmd/app/ls.go
+++ b/cmd/app/ls.go
@@ -27,7 +27,6 @@ func init() {
 	appCmd.AddCommand(lsCmd)
 
 	lsCmd.Flags().BoolP("details", "d", false, "Show details of the apps")
-	lsCmd.Flags().BoolP("numbers", "n", false, "Show the index numbers of the applications")
 }
 
 func runAppLs(cmd *cobra.Command, args []string) {
@@ -42,32 +41,39 @@ func runAppLs(cmd *cobra.Command, args []string) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	numbers, err := cmd.Flags().GetBool("numbers")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	lenf := strconv.Itoa(len(apps.Apps) - 1)
-	printf := "%" + lenf + "v %s\n"
-	tabf := fmt.Sprintf("%"+lenf+"v    ", "")
-
-	for i, a := range apps.Apps {
-		if numbers {
-			fmt.Printf(printf, i, a.Repo)
-		} else {
-			fmt.Println(a.Repo)
+	idMaxLength := 0
+	for _, a := range apps.Apps {
+		if len(a.ID) > idMaxLength {
+			idMaxLength = len(a.ID)
 		}
+	}
+	lenf := strconv.Itoa(idMaxLength)
+	printf := "%" + lenf + "v  %s\n"
+	tabf := fmt.Sprintf("%"+lenf+"v", "")
 
+	if !details {
+		fmt.Printf("ID%sRepository\n", tabf)
+	}
+
+	for _, a := range apps.Apps {
 		if details {
-			fmt.Printf("%sStatus: %t\n", tabf, a.Status)
-			fmt.Printf("%sAutoDeploy: %s\n", tabf, a.AutoDeploy)
-			fmt.Printf("%sDefaultEnv: %s\n", tabf, a.DefaultEnv)
-			fmt.Printf("%sEndpoint: %s\n", tabf, a.Endpoint)
-			fmt.Printf("%sDisplayName: %s\n", tabf, a.DisplayName)
-			fmt.Printf("%sCreatedAt: %s\n", tabf, time.Unix(int64(a.CreatedAt), 0))
-			fmt.Printf("%sDeployedAt: %s\n", tabf, time.Unix(int64(a.DeployedAt), 0))
+			fmt.Printf("Repo: %s\n", a.Repo)
+			fmt.Printf("  ID: %s\n", a.ID)
+			fmt.Printf("  Status: %t\n", a.Status)
+			fmt.Printf("  AutoDeploy: %s\n", a.AutoDeploy)
+			fmt.Printf("  DefaultEnv: %s\n", a.DefaultEnv)
+			fmt.Printf("  Endpoint: %s\n", a.Endpoint)
+			fmt.Printf("  DisplayName: %s\n", a.DisplayName)
+			fmt.Printf("  CreatedAt: %s\n", time.Unix(int64(a.CreatedAt), 0))
+			fmt.Printf("  DeployedAt: %s\n", time.Unix(int64(a.DeployedAt), 0))
 			fmt.Println()
+		} else {
+			fmt.Printf(printf, a.ID, a.Repo)
 		}
 	}
 }

--- a/cmd/app/ls.go
+++ b/cmd/app/ls.go
@@ -2,9 +2,7 @@ package app
 
 import (
 	"fmt"
-	"os"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stormkit-io/stormkit-cli/api"
@@ -20,7 +18,7 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Run: runAppLs,
+	RunE: runAppLs,
 }
 
 func init() {
@@ -29,21 +27,15 @@ func init() {
 	lsCmd.Flags().BoolP("details", "d", false, "Show details of the apps")
 }
 
-func runAppLs(cmd *cobra.Command, args []string) {
+func runAppLs(cmd *cobra.Command, args []string) error {
 	apps, err := api.GetApps()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	details, err := cmd.Flags().GetBool("details")
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	idMaxLength := 0
@@ -62,18 +54,11 @@ func runAppLs(cmd *cobra.Command, args []string) {
 
 	for _, a := range apps.Apps {
 		if details {
-			fmt.Printf("Repo: %s\n", a.Repo)
-			fmt.Printf("  ID: %s\n", a.ID)
-			fmt.Printf("  Status: %t\n", a.Status)
-			fmt.Printf("  AutoDeploy: %s\n", a.AutoDeploy)
-			fmt.Printf("  DefaultEnv: %s\n", a.DefaultEnv)
-			fmt.Printf("  Endpoint: %s\n", a.Endpoint)
-			fmt.Printf("  DisplayName: %s\n", a.DisplayName)
-			fmt.Printf("  CreatedAt: %s\n", time.Unix(int64(a.CreatedAt), 0))
-			fmt.Printf("  DeployedAt: %s\n", time.Unix(int64(a.DeployedAt), 0))
-			fmt.Println()
+			fmt.Print(api.DumpApp(a))
 		} else {
 			fmt.Printf(printf, a.ID, a.Repo)
 		}
 	}
+
+	return nil
 }

--- a/cmd/app/ls_test.go
+++ b/cmd/app/ls_test.go
@@ -31,6 +31,7 @@ func runAppLsInit() (*httptest.Server, *cobra.Command) {
 func TestRunAppLsNotServer(t *testing.T) {
 	stormkit.Config()
 
+	viper.Set("app.server", "")
 	cmd := cobra.Command{}
 	args := []string{}
 
@@ -40,7 +41,8 @@ func TestRunAppLsNotServer(t *testing.T) {
 }
 
 func TestRunAppLsNoFlag(t *testing.T) {
-	_, cmd := runAppUseInit()
+	s, cmd := runAppUseInit()
+	defer s.Close()
 	args := []string{}
 
 	err := runAppLs(cmd, args)
@@ -49,7 +51,8 @@ func TestRunAppLsNoFlag(t *testing.T) {
 }
 
 func TestRunAppLs(t *testing.T) {
-	_, cmd := runAppLsInit()
+	s, cmd := runAppLsInit()
+	defer s.Close()
 	args := []string{}
 
 	f := func() {
@@ -57,7 +60,7 @@ func TestRunAppLs(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	s := testutils.CaptureOutput(f)
+	out := testutils.CaptureOutput(f)
 
 	expectedOutput := fmt.Sprintf(
 		"ID   Repository\n%s  %s\n%s  %s\n",
@@ -66,11 +69,12 @@ func TestRunAppLs(t *testing.T) {
 		expectedApps.Apps[1].ID,
 		expectedApps.Apps[1].Repo,
 	)
-	assert.Equal(t, expectedOutput, s)
+	assert.Equal(t, expectedOutput, out)
 }
 
 func TestRunAppLsDetails(t *testing.T) {
-	_, cmd := runAppLsInit()
+	s, cmd := runAppLsInit()
+	defer s.Close()
 	args := []string{}
 	cmd.Flags().Set("details", "true")
 
@@ -79,12 +83,12 @@ func TestRunAppLsDetails(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	s := testutils.CaptureOutput(f)
+	out := testutils.CaptureOutput(f)
 
 	a := expectedApps.Apps[0]
 	a0 := api.DumpApp(a)
 	a = expectedApps.Apps[1]
 	a1 := api.DumpApp(a)
 
-	assert.Equal(t, a0+a1, s)
+	assert.Equal(t, a0+a1, out)
 }

--- a/cmd/app/ls_test.go
+++ b/cmd/app/ls_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stormkit-io/stormkit-cli/api"
+	"github.com/stormkit-io/stormkit-cli/stormkit"
+	"github.com/stormkit-io/stormkit-cli/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func runAppLsInit() (*httptest.Server, *cobra.Command) {
+	j, _ := json.Marshal(expectedApps)
+	s := testutils.ServerMock("/apps", j, http.StatusOK)
+
+	viper.Set("app.server", s.URL[7:len(s.URL)])
+	stormkit.Config()
+
+	cmd := cobra.Command{}
+	cmd.Flags().Bool("details", false, "")
+
+	return s, &cmd
+}
+
+func TestRunAppLsNotServer(t *testing.T) {
+	stormkit.Config()
+
+	cmd := cobra.Command{}
+	args := []string{}
+
+	err := runAppLs(&cmd, args)
+
+	assert.Equal(t, `Get "http:///apps": http: no Host in request URL`, err.Error())
+}
+
+func TestRunAppLsNoFlag(t *testing.T) {
+	_, cmd := runAppUseInit()
+	args := []string{}
+
+	err := runAppLs(cmd, args)
+
+	assert.Equal(t, `flag accessed but not defined: details`, err.Error())
+}
+
+func TestRunAppLs(t *testing.T) {
+	_, cmd := runAppLsInit()
+	args := []string{}
+
+	f := func() {
+		err := runAppLs(cmd, args)
+		assert.Nil(t, err)
+	}
+
+	s := testutils.CaptureOutput(f)
+
+	expectedOutput := fmt.Sprintf(
+		"ID   Repository\n%s  %s\n%s  %s\n",
+		expectedApps.Apps[0].ID,
+		expectedApps.Apps[0].Repo,
+		expectedApps.Apps[1].ID,
+		expectedApps.Apps[1].Repo,
+	)
+	assert.Equal(t, expectedOutput, s)
+}
+
+func TestRunAppLsDetails(t *testing.T) {
+	_, cmd := runAppLsInit()
+	args := []string{}
+	cmd.Flags().Set("details", "true")
+
+	f := func() {
+		err := runAppLs(cmd, args)
+		assert.Nil(t, err)
+	}
+
+	s := testutils.CaptureOutput(f)
+
+	a := expectedApps.Apps[0]
+	a0 := api.DumpApp(a)
+	a = expectedApps.Apps[1]
+	a1 := api.DumpApp(a)
+
+	assert.Equal(t, a0+a1, s)
+}

--- a/cmd/app/use_test.go
+++ b/cmd/app/use_test.go
@@ -52,6 +52,7 @@ func runAppUseInit() (*httptest.Server, *cobra.Command) {
 }
 
 func TestRunAppUseNotServer(t *testing.T) {
+	viper.Set("app.server", "")
 	stormkit.Config()
 
 	cmd := cobra.Command{}

--- a/cmd/app/use_test.go
+++ b/cmd/app/use_test.go
@@ -16,8 +16,26 @@ import (
 
 var expectedApps = api.Apps{
 	Apps: []api.App{
-		{ID: "123", Repo: "repo0"},
-		{ID: "124", Repo: "repo1"},
+		{
+			ID:          "123",
+			Repo:        "github/user0/repo0",
+			Status:      true,
+			AutoDeploy:  "commit",
+			DefaultEnv:  "production",
+			DisplayName: "test",
+			CreatedAt:   1019284842,
+			DeployedAt:  19340538292,
+		},
+		{
+			ID:          "124",
+			Repo:        "github/user0/repo1",
+			Status:      false,
+			AutoDeploy:  "pr",
+			DefaultEnv:  "production",
+			DisplayName: "test2",
+			CreatedAt:   1920038421,
+			DeployedAt:  2910198384,
+		},
 	},
 }
 

--- a/stormkit/main_test.go
+++ b/stormkit/main_test.go
@@ -1,16 +1,13 @@
 package stormkit
 
 import (
-	"bytes"
 	"errors"
-	"io"
-	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/stormkit-io/stormkit-cli/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -76,7 +73,7 @@ app:
   - id: ` + expectedAppID), nil
 	}
 
-	re := captureOutput(func() {
+	re := testutils.CaptureOutput(func() {
 		ConfigWithPath(".")
 	})
 
@@ -99,42 +96,12 @@ app:
   - id: "ccccc"`), nil
 	}
 
-	re := captureOutput(func() {
+	re := testutils.CaptureOutput(func() {
 		Config()
 		ConfigWithPath("./test")
 	})
 
 	assert.Equal(t, "there are many apps in the config file (using the first)\n", re)
-}
-
-func captureOutput(f func()) string {
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		panic(err)
-	}
-	stdout := os.Stdout
-	stderr := os.Stderr
-	defer func() {
-		os.Stdout = stdout
-		os.Stderr = stderr
-		log.SetOutput(os.Stderr)
-	}()
-	os.Stdout = writer
-	os.Stderr = writer
-	log.SetOutput(writer)
-	out := make(chan string)
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		var buf bytes.Buffer
-		wg.Done()
-		io.Copy(&buf, reader)
-		out <- buf.String()
-	}()
-	wg.Wait()
-	f()
-	writer.Close()
-	return <-out
 }
 
 func TestGetStormkitConfigFilePathNotExits(t *testing.T) {

--- a/testutils/iotesting.go
+++ b/testutils/iotesting.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+// CaptureOutput of the function given as arguemnt and returns it
+func CaptureOutput(f func()) string {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	stderr := os.Stderr
+	defer func() {
+		os.Stdout = stdout
+		os.Stderr = stderr
+		log.SetOutput(os.Stderr)
+	}()
+	os.Stdout = writer
+	os.Stderr = writer
+	log.SetOutput(writer)
+	out := make(chan string)
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		var buf bytes.Buffer
+		wg.Done()
+		io.Copy(&buf, reader)
+		out <- buf.String()
+	}()
+	wg.Wait()
+	f()
+	writer.Close()
+	return <-out
+}


### PR DESCRIPTION
Main change: fix `$ stomkit-cli app ls` variables dump.

Minor changes:
- moved `CaptureOutput` from `stormkit` to `testutils` package.
- created `api.DumpApp` function
- fixed unit tests